### PR TITLE
Parse data at the ward level; format data better

### DIFF
--- a/index.js
+++ b/index.js
@@ -116,7 +116,7 @@ const parseContest = (splitFile, targetContest, nextContest) => {
 		const parsedLine = line.replace("\\", "");
 		const result = new RegExp(/([-a-zA-Z' ]*) ([0-9]*) ([0-9.]*)%/).exec(parsedLine);
 		if (result && result.length >= 4) {
-			candidateData.numVotes = result[2];
+			candidateData.numVotes = parseInt(result[2], 10);
 			candidateData.percentageVotes = result[3];
 			returnData.results[result[1]] = candidateData;
 			if (result[1] !== "Write-in Votes") {
@@ -172,7 +172,34 @@ const splitWardFile = async () => {
 			console.log("NO WARD FOUND");
 		}
 	}
+	for (const [key, data] of Object.entries(returnData)) {
+		const wardData = returnData[key];
+		const combinedData = combineWardResults(data);
+		returnData[key] = { ...wardData, ...combinedData };
+	}
 	console.log(JSON.stringify(returnData));
+};
+
+const combineWardResults = (contestData) => {
+	const returnData = {
+		results: {},
+		totalVotes: 0
+	};
+	for (const [key, data] of Object.entries(contestData)) {
+		if (key === "candidates") {
+			continue;
+		}
+		returnData.totalVotes += data.totalVotes;
+		for (const [candidate, resultData] of Object.entries(data.results)) {
+			if (!(candidate in returnData.results)) {
+				returnData.results[candidate] = {
+					numVotes: 0
+				};
+			}
+			returnData.results[candidate].numVotes += resultData.numVotes;
+		}
+	}
+	return returnData;
 };
 
 const parseResults = (splicedFile) => {

--- a/index.js
+++ b/index.js
@@ -139,6 +139,7 @@ const loadPdfFromArgs = async () => {
 
 const splitWardFile = async () => {
 	const parsedFile = await loadPdfFromArgs();
+
 	const returnData = {};
 	if (!parsedFile) {
 		console.log("no parsed file");
@@ -157,7 +158,16 @@ const splitWardFile = async () => {
 		if (currentWardStart >= 0) {
 			const wardResults = parsedFile.splice(currentWardStart - 4, nextWardStart);
 			const parsedWardResults = parseResults(wardResults);
-			returnData[i.toString()] = parsedWardResults;
+			for (const [key, data] of Object.entries(parsedWardResults.results)) {
+				if (!(key in returnData)) {
+					returnData[key] = {
+						candidates: data.candidates
+					};
+				}
+				// TODO: this is really dumb and i should make a better way of handling this
+				delete data.candidates;
+				returnData[key][i.toString()] = data;
+			}
 		} else {
 			console.log("NO WARD FOUND");
 		}
@@ -181,26 +191,4 @@ const parseResults = (splicedFile) => {
 	return returnData;
 };
 
-const processFile = async () => {
-	const parsedFile = loadPdfFromArgs();
-	if (!parsedFile) {
-		return;
-	}
-	// The first 10 lines are the main header
-	const headerData = parseHeaderData(parsedFile.slice(0, 10));
-	const noHeaderFile = removeHeaders(parsedFile);
-	const fileContests = findContests(noHeaderFile);
-	const raceData = {};
-	for (let i = 0; i < fileContests.length; i++) {
-		if (i + 1 >= fileContests.length) {
-			raceData[fileContests[i]] = parseContest(noHeaderFile, fileContests[i], false);
-		} else {
-			raceData[fileContests[i]] = parseContest(noHeaderFile, fileContests[i], fileContests[i + 1]);
-		}
-	}
-	headerData.results = raceData;
-	console.log(JSON.stringify(headerData));
-};
-
-//processFile();
 splitWardFile();


### PR DESCRIPTION
This change allows the program to take input from the Ward Level PDFs. I also considered doing precinct level parsing, but that document has a different structure, so I'm going to save that project for later.

This also organizes the data in a way that should be easier to use for folks - it's sorted by the contests first (US Senator, etc) and then by wards within those contests.

There's likely some things we could add to tidy this up/add more options, but I think this gives us a pretty good base to work off of. Let me know how it looks!